### PR TITLE
Add auto discovery for the facade and serviceprovider

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Once installed add the service provider and facade to your app config
     'Favourites' => 'Mintbridge\EloquentFavourites\FavouritesFacade',
 ];
 ```
+Laravel 5.5 uses Package Auto-Discovery, so doesn't require you to manually add the ServiceProvider.
 
 You'll also need to publish and run the migration in order to create the database table.
 ```

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,15 @@
             "Mintbridge\\EloquentFavourites\\Test\\": "tests/"
         }
     },
+	"extra": {		
+        "laravel": {
+            "providers": [
+                "Mintbridge\\EloquentFavourites\\FavouritesServiceProvider"
+            ],
+            "aliases": {
+                "Favourites": "Mintbridge\\EloquentFavourites\\FavouritesFacade"
+            }
+        }
+	},
     "minimum-stability": "stable"
 }


### PR DESCRIPTION
As from Laravel 5.5, you can add an auto discovery section as Taylor describes in here: https://medium.com/@taylorotwell/package-auto-discovery-in-laravel-5-5-ea9e3ab20518